### PR TITLE
Fix polling-queue starvation that froze Loops dispatch for a day

### DIFF
--- a/app/models/field_value_baseline.rb
+++ b/app/models/field_value_baseline.rb
@@ -7,7 +7,6 @@ class FieldValueBaseline < ApplicationRecord
   scope :for_sync_source, ->(source) { where(sync_source_id: source.id) }
 
   # One-shot detect + persist (baseline on first see; update if changed)
-  # This is the single public API method for using this model
   #
   # @param sync_source [SyncSource] The sync source this baseline belongs to
   # @param row_id [String] Combined table_id and record_id (e.g., "tbl123_rec456")
@@ -20,37 +19,94 @@ class FieldValueBaseline < ApplicationRecord
   #   - first_time: Boolean indicating if this is the first time seeing this row+field
   #   - old_value: The previous value before this update (nil if first_time)
   def self.detect_change(sync_source:, row_id:, field_id:, current_value:, checked_at: Time.current)
-    bl = find_or_initialize_by(
-      sync_source_id: sync_source.id,
-      row_id: row_id,
-      field_id: field_id
+    results = detect_changes_batch(
+      sync_source: sync_source,
+      checks: [ { row_id: row_id, field_id: field_id, current_value: current_value } ],
+      checked_at: checked_at
     )
-    first_time = bl.new_record?
+    result = results[[ row_id, field_id ]]
+    baseline = find_by!(sync_source_id: sync_source.id, row_id: row_id, field_id: field_id)
 
-    # Capture old value BEFORE updating baseline
-    old_value = bl.last_known_value
+    { baseline: baseline, changed: result[:changed], first_time: result[:first_time], old_value: result[:old_value] }
+  end
 
-    if first_time
-      changed = true
-    else
-      changed = bl.send(:value_changed?, current_value)
+  # Batch variant of detect_change: detects and persists all checks for one
+  # sync source in three statements (one SELECT, one bulk bookkeeping UPDATE
+  # for unchanged rows, one upsert for new/changed rows) instead of a
+  # SELECT + UPDATE per row+field. Polls check every Loops field of every
+  # fetched record each cycle, so the per-check writes of the one-shot API
+  # dominated poll time on large tables.
+  #
+  # @param sync_source [SyncSource] The sync source these baselines belong to
+  # @param checks [Array<Hash>] Hashes with :row_id, :field_id, :current_value.
+  #   Duplicate row+field pairs are collapsed (last one wins).
+  # @param checked_at [Time] When this check occurred (defaults to Time.current)
+  # @return [Hash] Keyed by [row_id, field_id], each value
+  #   { changed:, first_time:, old_value: } with the same semantics as
+  #   detect_change.
+  def self.detect_changes_batch(sync_source:, checks:, checked_at: Time.current)
+    deduped = {}
+    checks.each { |check| deduped[[ check[:row_id], check[:field_id] ]] = check[:current_value] }
+    return {} if deduped.empty?
+
+    existing = where(sync_source_id: sync_source.id, row_id: deduped.keys.map(&:first).uniq)
+                 .index_by { |bl| [ bl.row_id, bl.field_id ] }
+
+    results = {}
+    upsert_rows = []
+    unchanged_ids = []
+
+    deduped.each do |(row_id, field_id), current_value|
+      baseline = existing[[ row_id, field_id ]]
+      canonical_value = canonicalize_value(current_value)
+
+      if baseline.nil?
+        results[[ row_id, field_id ]] = { changed: true, first_time: true, old_value: nil }
+        upsert_rows << {
+          sync_source_id: sync_source.id,
+          row_id: row_id,
+          field_id: field_id,
+          last_known_value: canonical_value,
+          value_last_updated_at: checked_at,
+          last_checked_at: checked_at,
+          first_seen_at: checked_at,
+          checked_count: 1
+        }
+      elsif canonical_value.to_json != canonicalize_value(baseline.last_known_value).to_json
+        results[[ row_id, field_id ]] = { changed: true, first_time: false, old_value: baseline.last_known_value }
+        upsert_rows << {
+          sync_source_id: sync_source.id,
+          row_id: row_id,
+          field_id: field_id,
+          last_known_value: canonical_value,
+          value_last_updated_at: checked_at,
+          last_checked_at: checked_at,
+          first_seen_at: baseline.first_seen_at || checked_at,
+          checked_count: (baseline.checked_count || 0) + 1
+        }
+      else
+        results[[ row_id, field_id ]] = { changed: false, first_time: false, old_value: baseline.last_known_value }
+        unchanged_ids << baseline.id
+      end
     end
 
-    if first_time
-      bl.last_known_value = bl.send(:canonicalize, current_value)
-      bl.value_last_updated_at = checked_at
-      bl.first_seen_at ||= checked_at if bl.respond_to?(:first_seen_at)
-    elsif changed
-      bl.last_known_value = bl.send(:canonicalize, current_value)
-      bl.value_last_updated_at = checked_at
+    if unchanged_ids.any?
+      # Rails also touches updated_at in update_all here (Rails 8 behavior),
+      # matching the save! the one-shot API used to do.
+      where(id: unchanged_ids).update_all(
+        [ "checked_count = checked_count + 1, last_checked_at = ?", checked_at ]
+      )
     end
 
-    bl.last_checked_at = checked_at
-    bl.first_seen_at ||= checked_at if bl.respond_to?(:first_seen_at)
-    bl.checked_count = (bl.checked_count || 0) + 1 if bl.respond_to?(:checked_count)
-    bl.save! if bl.changed? || bl.new_record?
+    if upsert_rows.any?
+      upsert_all(
+        upsert_rows,
+        unique_by: %i[sync_source_id row_id field_id],
+        update_only: %i[last_known_value value_last_updated_at last_checked_at checked_count]
+      )
+    end
 
-    { baseline: bl, changed: changed, first_time: first_time, old_value: old_value }
+    results
   end
 
   # Admin/cron helper to purge stale entries
@@ -58,6 +114,18 @@ class FieldValueBaseline < ApplicationRecord
   # @return [Integer] Number of records deleted
   def self.prune_stale(older_than:)
     stale_before(older_than).in_batches.delete_all
+  end
+
+  # Keep this lightweight and consistent for hashing/compare
+  def self.canonicalize_value(obj)
+    case obj
+    when Hash
+      obj.keys.sort.each_with_object({}) { |k, h| h[k.to_s] = canonicalize_value(obj[k]) }
+    when Array
+      obj.map { |v| canonicalize_value(v) }
+    else
+      obj
+    end
   end
 
   private
@@ -68,15 +136,7 @@ class FieldValueBaseline < ApplicationRecord
     canonicalize(new_value).to_json != canonicalize(last_known_value).to_json
   end
 
-  # Keep this lightweight and consistent for hashing/compare
   def canonicalize(obj)
-    case obj
-    when Hash
-      obj.keys.sort.each_with_object({}) { |k, h| h[k.to_s] = canonicalize(obj[k]) }
-    when Array
-      obj.map { |v| canonicalize(v) }
-    else
-      obj
-    end
+    self.class.canonicalize_value(obj)
   end
 end

--- a/app/services/pollers/airtable_to_loops.rb
+++ b/app/services/pollers/airtable_to_loops.rb
@@ -5,6 +5,11 @@ module Pollers
 
     DISPLAY_NAME_UPDATE_INTERVAL = 24.hours
 
+    # Records per baseline-detection batch. Bounds the size of the IN-list
+    # SELECT and the bulk write statements when a full-table resync fetches
+    # tens of thousands of records.
+    BASELINE_BATCH_SIZE = 500
+
     def call(sync_source)
       base_id = sync_source.source_id
       poll_start_time = Time.current.utc
@@ -256,48 +261,65 @@ module Pollers
     def detect_changes(sync_source, base_id, table_id, records, table, email_field, loops_fields)
       changed_records = []
 
-      records.each do |record|
-        record_id = record["id"]
-        row_id = row_identifier(table_id, record_id)
-        record_fields = record["fields"] || {}
-        changed_values = {}
+      # Baselines are detected and persisted in bulk, one batch of records at
+      # a time, instead of a SELECT + UPDATE per record+field. Every poll
+      # checks every Loops field of every fetched record, so per-check
+      # statements dominated poll time on large tables.
+      records.each_slice(BASELINE_BATCH_SIZE) do |record_slice|
+        checks = []
 
-        # Only iterate through Loops fields - we only create baselines for Loops fields
-        loops_fields.each do |field_id, field|
-          field_name = field["name"]
-          field_id_key = field_identifier(field_id, field_name)
+        record_slice.each do |record|
+          row_id = row_identifier(table_id, record["id"])
+          record_fields = record["fields"] || {}
 
-          # Get current value from record_fields (nil if not present, meaning field is null/empty)
-          current_value_raw = record_fields[field_name]
-          current_value = ValueNormalizer.from_airtable(current_value_raw)
+          # Only check Loops fields - we only create baselines for Loops fields
+          loops_fields.each do |field_id, field|
+            field_name = field["name"]
 
-          result = FieldValueBaseline.detect_change(
-            sync_source: sync_source,
-            row_id: row_id,
-            field_id: field_id_key,
-            current_value: current_value
-          )
+            # Get current value from record_fields (nil if not present, meaning field is null/empty)
+            current_value_raw = record_fields[field_name]
 
-          if result[:changed]
-            # Include old_value and modified_at for the job
-            # old_value comes from the result (nil if first_time)
-            # Use string keys for Sidekiq JSON serialization compatibility
-            changed_values[field_id_key] = {
-              "value" => current_value,
-              "old_value" => result[:old_value],
-              "modified_at" => Time.current.iso8601
+            checks << {
+              row_id: row_id,
+              field_id: field_identifier(field_id, field_name),
+              current_value: ValueNormalizer.from_airtable(current_value_raw)
             }
           end
         end
 
-        # If ANY field changed, send to the job
-        unless changed_values.empty?
-          email = record_fields[email_field["name"]]
-          changed_records << {
-            id: record_id,
-            email: email,
-            changedValues: changed_values
-          }
+        results = FieldValueBaseline.detect_changes_batch(sync_source: sync_source, checks: checks)
+
+        record_slice.each do |record|
+          record_id = record["id"]
+          row_id = row_identifier(table_id, record_id)
+          record_fields = record["fields"] || {}
+          changed_values = {}
+
+          loops_fields.each do |field_id, field|
+            field_name = field["name"]
+            field_id_key = field_identifier(field_id, field_name)
+            result = results[[ row_id, field_id_key ]]
+            next unless result && result[:changed]
+
+            # Include old_value and modified_at for the job
+            # old_value comes from the result (nil if first_time)
+            # Use string keys for Sidekiq JSON serialization compatibility
+            changed_values[field_id_key] = {
+              "value" => ValueNormalizer.from_airtable(record_fields[field_name]),
+              "old_value" => result[:old_value],
+              "modified_at" => Time.current.iso8601
+            }
+          end
+
+          # If ANY field changed, send to the job
+          unless changed_values.empty?
+            email = record_fields[email_field["name"]]
+            changed_records << {
+              id: record_id,
+              email: email,
+              changedValues: changed_values
+            }
+          end
         end
       end
 

--- a/app/workers/sync_source_poll_worker.rb
+++ b/app/workers/sync_source_poll_worker.rb
@@ -8,6 +8,15 @@ class SyncSourcePollWorker
   # The value is arbitrary but documented here for clarity
   ADVISORY_LOCK_NAMESPACE = 0x53535057  # ASCII: "SSPW" (SyncSourcePollWorker)
 
+  # The enqueuer reserves next_poll_at forward when it enqueues, so it emits
+  # exactly one job per source per poll interval. When the polling queue runs
+  # behind, several of those jobs for the same source sit in the queue at
+  # once; the advisory lock serializes them but each would still run a full
+  # poll back-to-back. A job that arrives sooner than this fraction of the
+  # poll interval after the previous attempt is such a backlog duplicate and
+  # is skipped. Jitter is at most ±10%, so on-schedule jobs always clear it.
+  DUPLICATE_SKIP_FRACTION = 0.5
+
   def perform(id)
     # Use PostgreSQL advisory lock to prevent concurrent execution
     # Advisory locks are per-connection, so we use with_connection to ensure
@@ -31,6 +40,12 @@ class SyncSourcePollWorker
       begin
         s = SyncSource.find_by(id: id)
         return unless s
+
+        min_gap_seconds = s.poll_interval_seconds * DUPLICATE_SKIP_FRACTION
+        if s.last_poll_attempted_at && s.last_poll_attempted_at > min_gap_seconds.seconds.ago
+          Rails.logger.info("SyncSourcePollWorker: Skipping #{id} - last attempt #{(Time.current - s.last_poll_attempted_at).round(1)}s ago, backlog duplicate")
+          return
+        end
 
         s.mark_attempt!
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,9 +1,13 @@
 ---
 concurrency: 5
+# Weighted queues: sidekiq samples queues proportionally to their weight
+# instead of always draining them in listed order. A plain (strict) list
+# starved `default` for a full day when `polling` demand exceeded worker
+# capacity — polling never emptied, so Loops dispatch never ran.
 queues:
-  - scheduler
-  - polling
-  - default
+  - ["scheduler", 6]
+  - ["polling", 3]
+  - ["default", 2]
 
 :schedule:
   sync_source_enqueuer:

--- a/test/models/field_value_baseline_test.rb
+++ b/test/models/field_value_baseline_test.rb
@@ -553,4 +553,110 @@ class FieldValueBaselineTest < ActiveSupport::TestCase
     )
     assert_equal array1, result4[:old_value], "old_value should work with array values"
   end
+
+  test "detect_changes_batch handles new, changed, and unchanged checks in one call" do
+    FieldValueBaseline.detect_change(
+      sync_source: @sync_source, row_id: "tbl1_rec1", field_id: "fldA", current_value: "same"
+    )
+    FieldValueBaseline.detect_change(
+      sync_source: @sync_source, row_id: "tbl1_rec2", field_id: "fldA", current_value: "before"
+    )
+
+    results = FieldValueBaseline.detect_changes_batch(
+      sync_source: @sync_source,
+      checks: [
+        { row_id: "tbl1_rec1", field_id: "fldA", current_value: "same" },
+        { row_id: "tbl1_rec2", field_id: "fldA", current_value: "after" },
+        { row_id: "tbl1_rec3", field_id: "fldA", current_value: "brand new" }
+      ]
+    )
+
+    unchanged = results[[ "tbl1_rec1", "fldA" ]]
+    refute unchanged[:changed], "Unchanged value should not be flagged"
+    refute unchanged[:first_time]
+    assert_equal "same", unchanged[:old_value]
+
+    changed = results[[ "tbl1_rec2", "fldA" ]]
+    assert changed[:changed], "Changed value should be flagged"
+    refute changed[:first_time]
+    assert_equal "before", changed[:old_value]
+
+    first_time = results[[ "tbl1_rec3", "fldA" ]]
+    assert first_time[:changed], "First time should be considered a change"
+    assert first_time[:first_time]
+    assert_nil first_time[:old_value]
+
+    assert_equal "after",
+      FieldValueBaseline.find_by(sync_source_id: @sync_source.id, row_id: "tbl1_rec2", field_id: "fldA").last_known_value
+    new_baseline = FieldValueBaseline.find_by(sync_source_id: @sync_source.id, row_id: "tbl1_rec3", field_id: "fldA")
+    assert_equal "brand new", new_baseline.last_known_value
+    assert_equal 1, new_baseline.checked_count
+  end
+
+  test "detect_changes_batch bumps bookkeeping without touching value timestamps on unchanged rows" do
+    first = FieldValueBaseline.detect_change(
+      sync_source: @sync_source, row_id: @row_id, field_id: @field_id, current_value: "stable"
+    )[:baseline]
+    original_value_updated_at = first.value_last_updated_at
+    original_checked_at = first.last_checked_at
+    original_count = first.checked_count
+
+    FieldValueBaseline.detect_changes_batch(
+      sync_source: @sync_source,
+      checks: [ { row_id: @row_id, field_id: @field_id, current_value: "stable" } ],
+      checked_at: original_checked_at + 10.seconds
+    )
+
+    reloaded = first.reload
+    assert_equal original_count + 1, reloaded.checked_count, "checked_count should increment"
+    assert reloaded.last_checked_at > original_checked_at, "last_checked_at should advance"
+    assert_equal original_value_updated_at, reloaded.value_last_updated_at,
+      "value_last_updated_at should not move when the value is unchanged"
+    assert_equal "stable", reloaded.last_known_value
+  end
+
+  test "detect_changes_batch collapses duplicate row and field pairs with last value winning" do
+    results = FieldValueBaseline.detect_changes_batch(
+      sync_source: @sync_source,
+      checks: [
+        { row_id: @row_id, field_id: @field_id, current_value: "first" },
+        { row_id: @row_id, field_id: @field_id, current_value: "second" }
+      ]
+    )
+
+    assert_equal 1, results.size
+    assert results[[ @row_id, @field_id ]][:first_time]
+    assert_equal "second",
+      FieldValueBaseline.find_by(sync_source_id: @sync_source.id, row_id: @row_id, field_id: @field_id).last_known_value
+  end
+
+  test "detect_changes_batch returns empty hash for empty checks" do
+    assert_equal({}, FieldValueBaseline.detect_changes_batch(sync_source: @sync_source, checks: []))
+  end
+
+  test "detect_changes_batch uses a bounded number of queries" do
+    10.times do |i|
+      FieldValueBaseline.detect_change(
+        sync_source: @sync_source, row_id: "tblq_rec#{i}", field_id: "fldQ", current_value: "v#{i}"
+      )
+    end
+
+    checks = []
+    10.times { |i| checks << { row_id: "tblq_rec#{i}", field_id: "fldQ", current_value: (i.even? ? "v#{i}" : "changed") } }
+    10.times { |i| checks << { row_id: "tblq_new#{i}", field_id: "fldQ", current_value: "new" } }
+
+    query_count = 0
+    counter = lambda do |_name, _start, _finish, _id, payload|
+      next if %w[SCHEMA TRANSACTION].include?(payload[:name])
+      next if payload[:sql] =~ /\A(BEGIN|COMMIT|SAVEPOINT|RELEASE)/i
+      query_count += 1
+    end
+
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+      FieldValueBaseline.detect_changes_batch(sync_source: @sync_source, checks: checks)
+    end
+
+    assert_operator query_count, :<=, 4,
+      "Batch detection should use a constant number of statements (SELECT + bulk UPDATE + upsert), got #{query_count}"
+  end
 end

--- a/test/workers/sync_source_poll_worker_test.rb
+++ b/test/workers/sync_source_poll_worker_test.rb
@@ -150,6 +150,10 @@ class SyncSourcePollWorkerTest < ActiveSupport::TestCase
       # Small delay to ensure lock is released
       sleep(0.05)
 
+      # Age the attempt past the backlog-duplicate guard so the second job
+      # counts as due rather than as a queued duplicate
+      @sync_source.update_columns(last_poll_attempted_at: 16.seconds.ago)
+
       # Run second job - should succeed now
       SyncSourcePollWorker.new.perform(@sync_source.id)
     ensure
@@ -192,6 +196,10 @@ class SyncSourcePollWorkerTest < ActiveSupport::TestCase
       # Small delay to ensure lock is released
       sleep(0.05)
 
+      # Age the attempt past the backlog-duplicate guard so the second job
+      # counts as due rather than as a queued duplicate
+      @sync_source.update_columns(last_poll_attempted_at: 16.seconds.ago)
+
       # Run second job - should succeed because lock was released
       SyncSourcePollWorker.new.perform(@sync_source.id)
     ensure
@@ -200,6 +208,61 @@ class SyncSourcePollWorkerTest < ActiveSupport::TestCase
 
     # Verify both attempted (even though first failed)
     assert_equal 2, execution_tracker[:count], "Second job should run after first releases lock on error"
+  end
+
+  test "skips backlog duplicate when last attempt is fresher than half the poll interval" do
+    @sync_source.update_columns(last_poll_attempted_at: 2.seconds.ago)
+    previous_attempt = @sync_source.reload.last_poll_attempted_at
+
+    call_tracker = { count: 0 }
+    mock_poller = Class.new do
+      def initialize(call_counter)
+        @call_counter = call_counter
+      end
+
+      def call(sync_source)
+        @call_counter[:count] += 1
+      end
+    end.new(call_tracker)
+
+    original_for = Poller.method(:for)
+    Poller.define_singleton_method(:for) { |_sync_source| mock_poller }
+
+    begin
+      SyncSourcePollWorker.new.perform(@sync_source.id)
+    ensure
+      Poller.define_singleton_method(:for, original_for)
+    end
+
+    assert_equal 0, call_tracker[:count], "Poller should not run for a backlog duplicate"
+    assert_equal previous_attempt, @sync_source.reload.last_poll_attempted_at,
+      "Skipped duplicate should not mark a new attempt"
+  end
+
+  test "polls when last attempt is older than half the poll interval" do
+    @sync_source.update_columns(last_poll_attempted_at: 16.seconds.ago)
+
+    call_tracker = { count: 0 }
+    mock_poller = Class.new do
+      def initialize(call_counter)
+        @call_counter = call_counter
+      end
+
+      def call(sync_source)
+        @call_counter[:count] += 1
+      end
+    end.new(call_tracker)
+
+    original_for = Poller.method(:for)
+    Poller.define_singleton_method(:for) { |_sync_source| mock_poller }
+
+    begin
+      SyncSourcePollWorker.new.perform(@sync_source.id)
+    ensure
+      Poller.define_singleton_method(:for, original_for)
+    end
+
+    assert_equal 1, call_tracker[:count], "Poller should run when the source is due"
   end
 
   test "different sync_source IDs do not interfere" do


### PR DESCRIPTION
## What happened

Since ~2026-07-14 17:00 UTC, the `default` Sidekiq queue (Loops dispatch, outbox prep, list sync) was fully starved — **zero Loops outbox envelopes were created for ~23h** and the queue backed up to ~21k jobs, with another ~12.6k duplicate jobs in `polling`.

Root cause chain (verified on prod):

1. ~23 new `Loops - stardance*` columns landed in large Airtable bases, and automations rewrite them en masse — every poll's `LAST_MODIFIED_TIME` filter now matches large record sets.
2. Baseline detection did a `SELECT` + `UPDATE` **per record per field, even when nothing changed** (the `checked_count`/`last_checked_at` bump forces a save). Baseline writes went from ~15k/day to **1.45M/day** against a 5.8M-row table. Average poll time went 2.0s → 3.7s.
3. At 3.7s/poll, demand (1,078 sources ÷ 30s = 35.9 polls/s) exceeded capacity (128 threads ÷ 3.7s = 34.9/s), so `polling` never emptied.
4. `config/sidekiq.yml` used a strict queue list (`scheduler`, `polling`, `default`) — `default` only ran when `polling` was empty, which was never.

## The fix

- **Weighted queues** (`scheduler: 6, polling: 3, default: 2`) — `default` can never fully starve again, whatever happens to polling load.
- **Backlog-duplicate skip in `SyncSourcePollWorker`** — the enqueuer emits one job per source per interval, so when the queue runs behind, ~12 copies per source pile up and each ran a full poll back-to-back. A job arriving sooner than half the poll interval after the last attempt now no-ops.
- **`FieldValueBaseline.detect_changes_batch`** — one `SELECT` + one bulk bookkeeping `UPDATE` + one `upsert_all` per batch of records (chunks of 500), replacing per-record-field statements. `detect_change` keeps identical semantics as a thin wrapper over the batch API, so all existing callers/tests are unchanged. Bookkeeping (`checked_count`, `last_checked_at`) still updates every check, so `prune_stale` behavior is preserved.

## Testing

- New tests: batch detection (new/changed/unchanged/dedupe/empty + a bounded-query-count assertion) and the duplicate-skip guard.
- Full suite run locally with CI-equivalent env: **no new failures** vs `main` (remaining failures on both are the pre-existing env-gated Loops/OpenAI-key tests).
- `rubocop` clean on all changed files.

## Incident mitigation already in place

A temporary container (`email-tools-sidekiq-default-temp` on the prod host) is draining the starved `default` queue right now so Loops sync is already flowing again; it will be removed once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)